### PR TITLE
fix: add --force-reinstall

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN pip install -U jupyter-server-proxy
 #RUN pip install -U git+https://github.com/blairdrummond/jupyter-rsession-proxy@a65a984
 
 # www_root_path branch
-RUN pip install -U git+https://github.com/ryanlovett/jupyter-rsession-proxy@9affe36
+RUN pip install -U --force-reinstall git+https://github.com/ryanlovett/jupyter-rsession-proxy@9affe36
 
 ## Become normal user again
 USER ${NB_USER}


### PR DESCRIPTION
Still does not work on binderhub, unfortunately. But does work locally.

When running this without `--force-reinstall`, I get `rstudio could not start in time`, which is fixed here. I tested with

```
CMD jupyter notebook --debug --ip 0.0.0.0 --NotebookApp.base_url="/notebook/blair/"
```

And rstudio works fine. (Locally only. No idea why binder doesn't work)